### PR TITLE
feat: pass custom discussion names to single widget component

### DIFF
--- a/src/components/GiscusComments.vue
+++ b/src/components/GiscusComments.vue
@@ -1,0 +1,34 @@
+<script lang="ts" setup>
+const props = defineProps<{ path: string }>();
+
+// These are temporary parameters, will be updated later
+const GiscusParams = {
+  host: "http://localhost:3000",
+  repo: "stuyk/giscus-test",
+  repoid: "R_kgDOLP4O2A",
+  category: "Proposals",
+  categoryid: "DIC_kwDOLP4O2M4CdE02",
+  mapping: "specific",
+};
+</script>
+
+<template>
+  <div>
+    <giscus-widget
+      id="comments"
+      :host="GiscusParams.host"
+      :repo="GiscusParams.repo"
+      :repoid="GiscusParams.repoid"
+      :category="GiscusParams.category"
+      :categoryid="GiscusParams.categoryid"
+      :mapping="GiscusParams.mapping"
+      :term="props.path"
+      reactionsenabled="1"
+      emitmetadata="0"
+      inputposition="top"
+      theme="light"
+      lang="en"
+      loading="lazy"
+    ></giscus-widget>
+  </div>
+</template>

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,8 +3,10 @@ import "./style.css";
 import App from "./App.vue";
 import router from "./router";
 import Giscus from "@giscus/vue";
+import GiscusCommentsComponent from "./components/GiscusComments.vue";
 
 const app = createApp(App);
 app.use(router);
 app.component("GiscusWidget", Giscus);
+app.component("GiscusComments", GiscusCommentsComponent);
 app.mount("#app");

--- a/src/views/ProposalView.vue
+++ b/src/views/ProposalView.vue
@@ -2,37 +2,12 @@
 import { useRoute } from "vue-router";
 
 const route = useRoute();
-
-// These are temporary parameters, will be updated later
-const GiscusParams = {
-  host: "http://localhost:3000",
-  repo: "stuyk/giscus-test",
-  repoid: "R_kgDOLP4O2A",
-  category: "Proposals",
-  categoryid: "DIC_kwDOLP4O2M4CdE02",
-  mapping: "pathname",
-};
+const commentPath = `Proposal #${route.params.id}`;
 </script>
 
 <template>
   <div>
-    <giscus-widget
-      id="comments"
-      :host="GiscusParams.host"
-      :repo="GiscusParams.repo"
-      :repoid="GiscusParams.repoid"
-      :category="GiscusParams.category"
-      :categoryid="GiscusParams.categoryid"
-      :mapping="GiscusParams.mapping"
-      term="Welcome to giscus!"
-      reactionsenabled="1"
-      emitmetadata="0"
-      inputposition="top"
-      theme="light"
-      lang="en"
-      loading="lazy"
-    ></giscus-widget>
-
+    <GiscusComments :path="commentPath" />
     {{ route.params.id }}
   </div>
 </template>


### PR DESCRIPTION
Wrapped up the giscus widget to a single component.

Why?

Most of the configuration is straight forward but the only thing that is different is how comments are fetched from the giscus app. This small tweak lets us specify custom discussion names to map either `links` or `proposals` to. 

Allowing for two separate topics for tracking.

In production the corresponding discussion titles created when a proposal has links, or comments added would look like:

```
Links #5
```

```
Proposal #5
```