### PR TITLE
fix: tab hover stuck on mouse leave

### DIFF
--- a/src/components/ui/UiTabs.vue
+++ b/src/components/ui/UiTabs.vue
@@ -2,7 +2,13 @@
   <DropDown v-model="tabIdx" :values="options" class="md:hidden" v-bind="$attrs" @select="changeTab" />
 
   <div class="hidden md:flex flex-col w-full pt-12 relative" v-bind="$attrs">
-    <div ref="toggler" class="flex flex-row w-full gap-6 md:gap-12 relative" role="radiogroup" aria-label="Switch" @mouseleave="changeTab(lastTab)">
+    <div
+      ref="toggler"
+      class="flex flex-row w-full gap-6 md:gap-12 relative"
+      role="radiogroup"
+      aria-label="Switch"
+      @mouseleave="changeTab(lastTab)"
+    >
       <!-- Tabs -->
       <div
         v-for="(option, index) in options"

--- a/tests/components/UserBalance.spec.ts
+++ b/tests/components/UserBalance.spec.ts
@@ -1,9 +1,11 @@
-import { test, expect } from '@playwright/experimental-ct-vue';
-import UserBalance from '../../src/components/helper/UserBalance.vue';
+import { test, expect } from "@playwright/experimental-ct-vue";
+import UserBalance from "../../src/components/helper/UserBalance.vue";
 
 test.use({ viewport: { width: 500, height: 500 } });
 
-test('UserBalance balance formatted display', async ({ mount }) => {
-  const component = await mount(UserBalance,{props: { address: "govgen1995thtfe5gs47wrrjg9gsq0xs0udq3lr8yk7z8", denom: "ugovgen"}});
-  await expect(component).toContainText('6.223631');
+test("UserBalance balance formatted display", async ({ mount }) => {
+  const component = await mount(UserBalance, {
+    props: { address: "govgen1995thtfe5gs47wrrjg9gsq0xs0udq3lr8yk7z8", denom: "ugovgen" },
+  });
+  await expect(component).toContainText("6.223631");
 });


### PR DESCRIPTION
The tab hover on the tabs will get stuck on the last entry you hovered over, this fix makes it so that the hover restores itself to the previously selected tab index.