### PR TITLE
blacklist more form elements

### DIFF
--- a/src/utility/purify.ts
+++ b/src/utility/purify.ts
@@ -15,6 +15,15 @@ export function purifyHtml(html: string) {
       "source",
       "textarea",
       "embed",
+      "label",
+      "select",
+      "button",
+      "fieldset",
+      "legend",
+      "datalist",
+      "output",
+      "option",
+      "optgroup",
     ],
   });
 }


### PR DESCRIPTION
Blacklisting additional form elements that could be included in GitHub comments and potentially confuse/mislead dapp users.

Source: https://www.w3schools.com/html/html_form_elements.asp