### PR TITLE
chore: add RPCs to CSP allow-list

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -26,7 +26,7 @@
   https://avatars.githubusercontent.com
   '''
   Strict-Transport-Security = "max-age=31536000; includeSubDomains"
-  Content-Security-Policy = "default-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; img-src 'self' data: https:; connect-src https://graphql-mainnet.govgen.io/v1/graphql https://graphql-devnet.govgen.dev/v1/graphql https://gh-discuss.devnet.govgen.dev https://plausible.io/api/event githubusercontent.com *.githubusercontent.com"
+  Content-Security-Policy = "default-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; img-src 'self' data: https:; connect-src https://graphql-mainnet.govgen.io/v1/graphql https://graphql-devnet.govgen.dev/v1/graphql https://rpc.govgen.io https://rpc.govgen.dev https://gh-discuss.devnet.govgen.dev https://plausible.io/api/event githubusercontent.com *.githubusercontent.com"
   X-Frame-Options = "SAMEORIGIN"
   X-Content-Type-Options = "nosniff"
   Referrer-Policy = "strict-origin"


### PR DESCRIPTION
I was trying to create a proposal on staging.govgen.dev but it's failed because of :

```
Refused to connect to 'https://rpc.govgen.dev/' because it violates the following Content Security Policy directive: "connect-src https://graphql-mainnet.govgen.io/v1/graphql https://graphql-devnet.govgen.dev/v1/graphql https://gh-discuss.devnet.govgen.dev/ https://plausible.io/api/event githubusercontent.com *.githubusercontent.com".
```
